### PR TITLE
Поменял ссылку на cloud-init

### DIFF
--- a/docs/en/main/additionals/migration/migrate-vmware/migrate-vmware.md
+++ b/docs/en/main/additionals/migration/migrate-vmware/migrate-vmware.md
@@ -37,7 +37,7 @@ To migrate a VM with EFI emulation, use [Hystax](/en/additionals/hystax/migratio
    cloud-init --version
    ```
 
-   If the utility is missing, [install](https://www.tencentcloud.com/document/product/213/12587) it.
+   If the utility is missing, [install](https://www.ibm.com/docs/en/powervc-cloud/2.0.0?topic=init-installing-configuring-cloud-linux) it.
 
 4. Create a file `/etc/netplan/50-cloud-init.yaml` with the following contents:
 

--- a/docs/ru/main/additionals/migration/migrate-vmware/migrate-vmware.md
+++ b/docs/ru/main/additionals/migration/migrate-vmware/migrate-vmware.md
@@ -36,7 +36,7 @@
    cloud-init --version
    ```
 
-   Если утилита отсутствует, [установите](https://www.tencentcloud.com/document/product/213/12587) ее.
+   Если утилита отсутствует, [установите](https://cloud-init.io/) ее.
 4. Создайте файл `/etc/netplan/50-cloud-init.yaml` со следующим содержимым:
 
    ```yaml

--- a/docs/ru/main/additionals/migration/migrate-vmware/migrate-vmware.md
+++ b/docs/ru/main/additionals/migration/migrate-vmware/migrate-vmware.md
@@ -36,7 +36,7 @@
    cloud-init --version
    ```
 
-   Если утилита отсутствует, [установите](https://cloud-init.io/) ее.
+   Если утилита отсутствует, [установите](https://www.ibm.com/docs/ru/powervc-cloud/2.0.0?topic=init-installing-configuring-cloud-linux) ее.
 4. Создайте файл `/etc/netplan/50-cloud-init.yaml` со следующим содержимым:
 
    ```yaml


### PR DESCRIPTION
Коллеги, добрый день.

Обратил внимание на то, что ссылка на скачивание cloud-init со страницы по переезду из VMware ведет на документацию Tencent Cloud. То, что это другое облако и, по сути, конкуренты - мелочь. А вот то, что они в своей документации предлагают ставить cloud-init не из репозиториев ОС, а скачивать с китайского сайта myqcloud.com, да еще и прямо пишут, что "cloud-init depends on qcloud-python, which is a software package recompiled by Tencent Cloud" - такое себе. 

Предлагаю поменять эту ссылку на официальный сайт cloud-init.