### PR TITLE
Уточнение по поводу ID проекта в инструкции по установке мониторинга

### DIFF
--- a/docs/ru/manage/monitoring/instructions/mon-setup-current/mon-setup-current.md
+++ b/docs/ru/manage/monitoring/instructions/mon-setup-current/mon-setup-current.md
@@ -63,6 +63,7 @@
       -Headers @{'X-Auth-Token' = '<токен доступа X-Subject-Token>'} `
       -Body $params | Select-Object -Expand Content
       ```
+      Обратите внимание, что mcsXXXXXXXXXX - это имя проекта, когда как его идентификатор можно узнать в разделе "Управление доступами" личного кабинета.
 
    </tabpanel>
    </tabs>


### PR DESCRIPTION
В техподдержку обратился клиент с задачей 2024020200051. У него не получалось установить мониторинг, т.к. он использовал mcspid вместо projectid. Клиенты практически всегда работают с mcspid, так что клиента можно понять. Я написал примечание в инструкции, чтобы в дальнейшем не было путаницы.

В англоязычную версию ничего не добавлял.